### PR TITLE
Disables automatic loneop event altogether.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -583,10 +583,10 @@ This is here to make the tiles around the station mininuke change when it's arme
 	if(fake)
 		STOP_PROCESSING(SSobj, src)
 		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
-	var/turf/newturf = get_turf(src)
+	/*var/turf/newturf = get_turf(src)
 	if(newturf && lastlocation == newturf)
 		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
-			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
+			var/datum/round_event_control/operative/sop = locate(/datum/round_event_control/operative) in SSevents.control
 			if(istype(loneop))
 				loneop.weight += 1
 				if(loneop.weight % 5 == 0)
@@ -600,7 +600,7 @@ This is here to make the tiles around the station mininuke change when it's arme
 			loneop.weight = max(loneop.weight - 1, 0)
 			if(loneop.weight % 5 == 0)
 				message_admins("[src] is on the move (currently in [ADMIN_VERBOSEJMP(newturf)]). The weight of Lone Operative is now [loneop.weight].")
-			log_game("[src] being on the move has reduced the weight of the Lone Operative event to [loneop.weight].")
+			log_game("[src] being on the move has reduced the weight of the Lone Operative event to [loneop.weight].")*/
 
 /obj/item/disk/nuclear/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## Changelog
:cl:
tweak: solo nuke-op is now an admin-only thingy, rather than an automatic event
/:cl: