### PR TITLE
Revert Round Length to 3 Hours

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -53,7 +53,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/lockdown = FALSE	//disallow transit after nuke goes off
 
-	var/auto_call = 144000 //SDS Change - shift time is ~3 hrs.
+	var/auto_call = 108000 //SDS Change - shift time is ~3 hrs.
 	var/auto_call_allowed = TRUE //If the shuttle is allowed to be automatically called or not
 	var/realtimeofstart = 0
 
@@ -77,7 +77,7 @@ SUBSYSTEM_DEF(shuttle)
 	if(!supply)
 		WARNING("No /obj/docking_port/mobile/supply placed on the map!")
 	realtimeofstart = world.realtime
-	auto_call = 144000
+	auto_call = 108000
 	return ..()
 
 /datum/controller/subsystem/shuttle/proc/initial_load()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What the title says.

## Why It's Good For The Game

First off, none of the stations were made with four hour rounds in mind. Telecommunication, for instance, runs out of power at around the two hour mark for instance. 

Furthermore, we have noticed that players tend to leave halfway through the round quite frequently, and we notice that there is a dead lull in the second half into the round when it comes to activity. Players that come in halfway will often to be left out of ongoing roleplay or will be met with a station that has a lower population than before.

## Changelog
Reduce shuttle autocall from 4 hours to 3 hours.