### PR TITLE
Adds Light Replacer to Engieborg

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -315,6 +315,7 @@
 		/obj/item/assembly/signaler/cyborg,
 		/obj/item/areaeditor/blueprints/cyborg,
 		/obj/item/electroadaptive_pseudocircuit,
+		/obj/item/lightreplacer/cyborg,
 		/obj/item/stack/sheet/metal/cyborg,
 		/obj/item/stack/sheet/glass/cyborg,
 		/obj/item/stack/sheet/rglass/cyborg,
@@ -329,6 +330,13 @@
 	moduleselect_icon = "engineer"
 	magpulsing = TRUE
 	hat_offset = -4
+
+/obj/item/robot_module/engineering/respawn_consumable(mob/living/silicon/robot/R, coeff = 1)
+	..()
+	var/obj/item/lightreplacer/LR = locate(/obj/item/lightreplacer) in basic_modules
+	if(LR)
+		for(var/i in 1 to coeff)
+			LR.Charge(R)
 
 /obj/item/robot_module/security
 	name = "Security"


### PR DESCRIPTION
## About The Pull Request

Adds the Light Replacer to Engineering Cyborg Module

## Why It's Good For The Game

Allowing the Engineering Cyborg to fix and create rooms with lights would be helpful over, since they do work on construction. 

## Changelog
:cl:
add: Adds Light Replacer to the Engineering Cyborg Module
/:cl:
