### PR TITLE
Adds Airlock Circuit to Engineering Cyborg (and a pen)

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -151,11 +151,14 @@
 		user.visible_message("[user] installs the electronics into the airlock assembly.", \
 							"<span class='notice'>You start to install electronics into the airlock assembly...</span>")
 		if(do_after(user, 40, target = src))
-			if( state != AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS )
-				return
-			if(!user.transferItemToLoc(W, src))
-				return
-
+			if(iscarbon(user))
+				if( state != AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS )
+					return
+				if(!user.transferItemToLoc(W, src))
+					return
+			else if(issilicon(user))
+				if( state != AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS )
+					return
 			to_chat(user, "<span class='notice'>You install the airlock electronics.</span>")
 			state = AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER
 			name = "near finished airlock assembly"
@@ -230,29 +233,53 @@
 
 		if(W.use_tool(src, user, 40, volume=100))
 			if(loc && state == AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER)
-				to_chat(user, "<span class='notice'>You finish the airlock.</span>")
-				var/obj/machinery/door/airlock/door
-				if(glass)
-					door = new glass_type( loc )
-				else
-					door = new airlock_type( loc )
-				door.setDir(dir)
-				door.unres_sides = electronics.unres_sides
-				//door.req_access = req_access
-				door.electronics = electronics
-				door.heat_proof = heat_proof_finished
-				if(electronics.one_access)
-					door.req_one_access = electronics.accesses
-				else
-					door.req_access = electronics.accesses
-				if(created_name)
-					door.name = created_name
-				else
-					door.name = base_name
-				door.previous_airlock = previous_assembly
-				electronics.forceMove(door)
-				door.update_icon()
-				qdel(src)
+				if(iscarbon(user))
+					to_chat(user, "<span class='notice'>You finish the airlock.</span>")
+					var/obj/machinery/door/airlock/door
+					if(glass)
+						door = new glass_type( loc )
+					else
+						door = new airlock_type( loc )
+					door.setDir(dir)
+					door.unres_sides = electronics.unres_sides
+					//door.req_access = req_access
+					door.electronics = electronics
+					door.heat_proof = heat_proof_finished
+					if(electronics.one_access)
+						door.req_one_access = electronics.accesses
+					else
+						door.req_access = electronics.accesses
+					if(created_name)
+						door.name = created_name
+					else
+						door.name = base_name
+					door.previous_airlock = previous_assembly
+					electronics.forceMove(door)
+					door.update_icon()
+					qdel(src)
+				else if(issilicon(user))
+					to_chat(user, "<span class='notice'>You finish the airlock.</span>")
+					var/obj/machinery/door/airlock/door
+					if(glass)
+						door = new glass_type( loc )
+					else
+						door = new airlock_type( loc )
+					door.setDir(dir)
+					door.unres_sides = electronics.unres_sides
+					//door.req_access = req_access
+					door.electronics = electronics
+					door.heat_proof = heat_proof_finished
+					if(electronics.one_access)
+						door.req_one_access = electronics.accesses
+					else
+						door.req_access = electronics.accesses
+					if(created_name)
+						door.name = created_name
+					else
+						door.name = base_name
+					door.previous_airlock = previous_assembly
+					door.update_icon()
+					qdel(src)
 	else
 		return ..()
 	update_name()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -202,21 +202,31 @@
 
 			//Adding airlock electronics for access. Step 6 complete.
 			else if(istype(W, /obj/item/electronics/airlock))
-				if(!user.transferItemToLoc(W, src))
-					return
-				W.play_tool_sound(src, 100)
-				user.visible_message("[user] installs the electronics into the airlock assembly.",
-					"<span class='notice'>You start to install electronics into the airlock assembly...</span>")
-
-				if(do_after(user, 40, target = src))
-					if(!src || electronics)
-						W.forceMove(drop_location())
+				if(iscarbon(user))
+					if(!user.transferItemToLoc(W, src))
 						return
-					to_chat(user, "<span class='notice'>You install the airlock electronics.</span>")
-					name = "near finished windoor assembly"
-					electronics = W
-				else
-					W.forceMove(drop_location())
+					W.play_tool_sound(src, 100)
+					user.visible_message("[user] installs the electronics into the airlock assembly.",
+						"<span class='notice'>You start to install electronics into the airlock assembly...</span>")
+
+					if(do_after(user, 40, target = src))
+						if(!src || electronics)
+							W.forceMove(drop_location())
+							return
+						to_chat(user, "<span class='notice'>You install the airlock electronics.</span>")
+						name = "near finished windoor assembly"
+						electronics = W
+					else
+						W.forceMove(drop_location())
+				else if(issilicon(user))
+					W.play_tool_sound(src, 100)
+					user.visible_message("[user] installs the electronics into the airlock assembly.",
+						"<span class='notice'>You start to install electronics into the airlock assembly...</span>")
+
+					if(do_after(user, 40, target = src))
+						to_chat(user, "<span class='notice'>You install the airlock electronics.</span>")
+						name = "near finished windoor assembly"
+						electronics = W
 
 			//Screwdriver to remove airlock electronics. Step 6 undone.
 			else if(istype(W, /obj/item/screwdriver))
@@ -260,26 +270,47 @@
 					to_chat(user, "<span class='notice'>You finish the windoor.</span>")
 
 					if(secure)
-						var/obj/machinery/door/window/brigdoor/windoor = new /obj/machinery/door/window/brigdoor(loc)
-						if(facing == "l")
-							windoor.icon_state = "leftsecureopen"
-							windoor.base_state = "leftsecure"
-						else
-							windoor.icon_state = "rightsecureopen"
-							windoor.base_state = "rightsecure"
-						windoor.setDir(dir)
-						windoor.density = FALSE
-
-						if(electronics.one_access)
-							windoor.req_one_access = electronics.accesses
-						else
-							windoor.req_access = electronics.accesses
-						windoor.electronics = electronics
-						electronics.forceMove(windoor)
-						if(created_name)
-							windoor.name = created_name
-						qdel(src)
-						windoor.close()
+						if(iscarbon(user))
+							var/obj/machinery/door/window/brigdoor/windoor = new /obj/machinery/door/window/brigdoor(loc)
+							if(facing == "l")
+								windoor.icon_state = "leftsecureopen"
+								windoor.base_state = "leftsecure"
+							else
+								windoor.icon_state = "rightsecureopen"
+								windoor.base_state = "rightsecure"
+							windoor.setDir(dir)
+							windoor.density = FALSE
+	
+							if(electronics.one_access)
+								windoor.req_one_access = electronics.accesses
+							else
+								windoor.req_access = electronics.accesses
+							windoor.electronics = electronics
+							electronics.forceMove(windoor)
+							if(created_name)
+								windoor.name = created_name
+							qdel(src)
+							windoor.close()
+						else if(issilicon(user))
+							var/obj/machinery/door/window/brigdoor/windoor = new /obj/machinery/door/window/brigdoor(loc)
+							if(facing == "l")
+								windoor.icon_state = "leftsecureopen"
+								windoor.base_state = "leftsecure"
+							else
+								windoor.icon_state = "rightsecureopen"
+								windoor.base_state = "rightsecure"
+							windoor.setDir(dir)
+							windoor.density = FALSE
+	
+							if(electronics.one_access)
+								windoor.req_one_access = electronics.accesses
+							else
+								windoor.req_access = electronics.accesses
+							windoor.electronics = electronics
+							if(created_name)
+								windoor.name = created_name
+							qdel(src)
+							windoor.close()
 
 
 					else

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -315,6 +315,8 @@
 		/obj/item/assembly/signaler/cyborg,
 		/obj/item/areaeditor/blueprints/cyborg,
 		/obj/item/electroadaptive_pseudocircuit,
+		/obj/item/electronics/airlock,
+		/obj/item/pen,
 		/obj/item/lightreplacer/cyborg,
 		/obj/item/stack/sheet/metal/cyborg,
 		/obj/item/stack/sheet/glass/cyborg,


### PR DESCRIPTION
## About The Pull Request

Adds the Airlock electronic circuit to the engineering cyborg so that they may construct airlocks and windoors manually, rather than having to rely on the RCD. Also includes a pen to the engineering borg.

## Why It's Good For The Game

So that a cyborg doesnt have to waste energy, they could just take a longer time and construct the airlock. Also allows the engineering cyborg to create windoors!
Pens allow cyborgs to rename doors during the creation of the airlock.

## Changelog
:cl:
add: Added the Airlock circuit to Engineering Cyborgs
add: Added a pen for renaming stuff for Engineering Cyborgs
add: Engineering Cyborgs can add airlock circuits to windoors and airlocks.
/:cl: