### PR TITLE
Engieborgs and Experimental Welders plus Airlock Circuit Fixes

### DIFF
--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -181,7 +181,10 @@
 			else
 				ae = electronics
 				electronics = null
-				ae.forceMove(src.loc)
+				if(iscarbon(user))
+					ae.forceMove(src.loc)
+				else
+					return
 
 	else if(istype(W, /obj/item/stack/sheet) && (!glass || !mineral))
 		var/obj/item/stack/sheet/G = W

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -242,7 +242,10 @@
 					var/obj/item/electronics/airlock/ae
 					ae = electronics
 					electronics = null
-					ae.forceMove(drop_location())
+					if(iscarbon(user))
+						ae.forceMove(drop_location())
+					else
+						return
 
 			else if(istype(W, /obj/item/pen))
 				var/t = stripped_input(user, "Enter the name for the door.", name, created_name,MAX_NAME_LEN)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -303,7 +303,7 @@
 		/obj/item/construction/rcd/borg,
 		/obj/item/pipe_dispenser,
 		/obj/item/extinguisher,
-		/obj/item/weldingtool/largetank/cyborg,
+		/obj/item/weldingtool/experimental,
 		/obj/item/screwdriver/cyborg,
 		/obj/item/wrench/cyborg,
 		/obj/item/crowbar/cyborg,


### PR DESCRIPTION
## About The Pull Request

The reason mostly for this is to fix some of the interactions that the airlock circuit has and the engieborg. Deconstructing had some weird interactions and so this should fix most of those. 

Also, this PR gives engieborgs experimental welding tools, because running out of fuel, and subsequently running around looking for tanks that may or may not have been sold off is frustrating. 

Sidenote: the commit regarding the pull request was to update my fork :)

## Why It's Good For The Game

These fixes and changes make engieborg just a little bit better.

## Changelog
:cl:
add: Added experimental welding tool to Engieborgs
del: Removed normal welding tool from Engieborgs
fix: Fixed some bugs with Airlock circuits within the Engieborgs
/:cl:

